### PR TITLE
Make lab links go to material id

### DIFF
--- a/_data/materials.yaml
+++ b/_data/materials.yaml
@@ -3,4 +3,4 @@
 - id: 0
   name: Info Session
   slides: https://docs.google.com/presentation/d/1tqg3xR4MHki29Rf_FCQJlrX01_A51gHGj55dR46D2G0/edit?usp=sharing
-  lab: 0
+  lab: https://goo.gl/forms/NoYFEGbOuAACIDMI3

--- a/_includes/calendar.html
+++ b/_includes/calendar.html
@@ -35,8 +35,8 @@
       </td>
       <td>
               {% if item.lab %}
-        <a href="labs/{{ item.lab }}">
-          Lab {{ item.lab }}
+        <a href="labs/{{ item.id }}">
+          Lab {{ item.id }}
         </a>
               {% else %}
         -


### PR DESCRIPTION
This should work, but if anyone wants to look it over to make sure there aren't any new bugs feel free to.