### PR TITLE
Fixed checkoff link

### DIFF
--- a/labs/b2.md
+++ b/labs/b2.md
@@ -144,7 +144,7 @@ Note: This behavior is from bash and some other shells that implement it.
  - `Ctrl-b [` can be used to scroll around buffers and copy things.
 
 ### Checking off
- Once you're done remember to fill out the [check off form](goo.gl/rDqwi7).
+ Once you're done remember to fill out the [check off form](https://goo.gl/rDqwi7).
  There are multiple valid answers for some of the questions.
  Don't be stressed about getting something exactly correct.
  Please answer the feedback questions if there's anything you want to say!


### PR DESCRIPTION
Added https:// to the front, otherwise markdown thinks it's a local link within the directory