### PR TITLE
Add lab a7

### DIFF
--- a/_data/materials.yaml
+++ b/_data/materials.yaml
@@ -71,6 +71,7 @@
 - id: a7
   name: Networked Services
   slides: https://docs.google.com/presentation/d/1k4L4oWoMbhkpS2XF84Mlcsun54MhM7nbnP5JZeDzVM0/edit
+  lab: a7
 
 - id: b8
   name: Security Fundamentals

--- a/labs/a7.md
+++ b/labs/a7.md
@@ -42,9 +42,6 @@ otherwise how would you have connected to the machine in the first place using
 SSH?  However, the other service (ntpd) is a bit more mysterious. Let's check
 it out!
 
-Note: If you've done lab 6 already, you might have some other services running
-here, like nginx or your toy service, but we'll skip those for this lab.
-
 ```
 $ man ntpd
 
@@ -106,6 +103,7 @@ for.
 
 To submit the lab, answer the questions in [this Google form][google-form].
 
+
 ## NFS
 
 We have provided a NFS server for you to connect to at `staff` with two
@@ -141,6 +139,7 @@ read files because it hands while doing so, please let us know on Piazza or by
 email (or at office hours if you'd prefer). We've had some problems in the past
 with NFS being very slow to mount/read and needing a restart.
 
+
 ## DNS
 
 In this section we are going to be setting up our own DNS server! Remember that
@@ -148,10 +147,10 @@ DNS is the system that maps from a domain like `ocf.berkeley.edu` to an IP like
 `169.229.226.23` (and `2607:f140:8801::1:23` for IPv6) so that computers know
 how to send information over the network to servers without people having to
 remember a bunch of numbers to connnect to everything. A more thorough
-description of this is in [Lab 5][lab-b5] if you'd like a refresher or want
+description of this is in [Lab 5][lab-a5] if you'd like a refresher or want
 more information.
 
-[lab-b5]: /labs/b5#dns
+[lab-a5]: /labs/a5#dns-configuration
 
 First, install the `bind9` package on your VM to set up a DNS server. By
 default, the service is not running yet. What is the `systemctl` command to
@@ -180,32 +179,24 @@ ExecStop=/usr/sbin/rndc stop
 WantedBy=multi-user.target
 ```
 
-This should look pretty familiar to you by now after doing lab 6! Don't worry
-if it doesn't all look familiar since there are some options you haven't seen
-yet in here, but you should at least recognize some of the options used.
+This should look pretty familiar to you after the lecture on services! Don't
+worry if it doesn't all look familiar since there are some options you haven't
+seen yet in here, but you should at least recognize some of the options used.
 
 If you now run `dig ocf.berkeley.edu @localhost` from your VM, you should see
 that the command eventually times out after trying to run for about 15 seconds.
-If you'd rather stop the command before then, just type Ctrl+C (in general this
-is a good way to try to stop a command that is running longer than you want it
-to).
-
-The previous command failed because the DNS server was not started yet. Try
-starting the DNS server using the relevant `systemctl` command. If you check
-the status of the `bind9` service after starting it, you should see the status
-has changed to say that the service is active and running.
+The previous command failed because the DNS server was not started yet (Doh!).
+Try starting the DNS server using the relevant `systemctl` command. If you
+check the status of the `bind9` service after starting it, you should see the
+status has changed to say that the service is active and running.
 
 If you now run `dig ocf.berkeley.edu @localhost` from your VM, you should now
 see a response containing the correct IP (`169.229.226.23`)!
 
-Now to the exciting part, the configuration. Edit (using `sudo` since it is
-owned by root) `/etc/bind/named.conf.local` with your favorite text editor
-(`nano` is a good choice to start out with if you haven't used terminal-based
-text editors before, `vim` or `emacs` are good for more experienced users or if
-you want more features than what `nano` offers). Inside this file, it should be
-empty apart from a few comments at the top because you haven't done any local
-configuration yet.  Add a new zone in this file for `example.com` with these
-contents:
+Now to the exciting part, the configuration! Edit `/etc/bind/named.conf.local`
+with your favorite text editor. Inside this file, it should be empty apart
+from a few comments at the top because you haven't done any local configuration
+yet. Add a new zone in this file for `example.com` with these contents:
 
 ```
 zone "example.com" {
@@ -221,36 +212,110 @@ there to get what you want for your config instead of having to start from
 scratch. To make this easier, we've provided a valid config at
 `/opt/lab7/db.example.com` that you can copy in place at
 `/etc/bind/db.example.com`. It is prefilled with your VM's IP, and includes a
-subdomain that does not usually exist, named `test.example.com`. Please add
-couple more records of your choice. Try to add one A record and one other type
-of record (CNAME, SRV, TXT, etc.).  Make sure to reload the `bind9` service
-after changing anything in `/etc/bind9`, since you want the running service to
-change its configuration.
+subdomain that does not usually exist, named `test.example.com`. Please add few
+more records of your choice. Try to add one A record, and a couple of other
+types of records (CNAME, SRV, TXT, etc.).  Make sure to reload the `bind9`
+service after changing anything in `/etc/bind9`, since you want the running
+service to change its configuration.
 
 If you now run the `dig` commands below, you should see that your VM's domain
 name (`<username>.decal.xcf.sh`) is returned for the first result, for the
 second result (`example.com`) your VM's IP address should be returned, and for
-`test.example.com` you should see `93.184.216.34` as the result. Also make
-sure to test the records you added and make sure they work! What commands did
-you use to query for your added records?
+`test.example.com` you should see `93.184.216.34` as the result.
 
-```
-$ dig NS example.com @localhost
-$ dig A example.com @localhost
-$ dig A test.example.com @localhost
-```
+What commands did you use to query for each of the records (including the ones
+you added)?
 
 Make sure to run these commands from your VM, or if you want to run them from
-your laptop or from an OCF computer, substitute `localhost` in the commands
+your laptop or from an OCF computer, substitute `localhost` in any commands
 with your VM's domain name (it'll be in the format `<username>.decal.xcf.sh`).
-Also make sure to do this from inside the Berkeley network so you don't get
-blocked by the firewall.
 
-### Extra Fun (optional)
+
+## Load Balancing
+
+For this section we will be using [HAProxy](https://www.haproxy.org/), a
+commonly-used open-source load balancer. [NGINX](https://nginx.org/) is
+actually [starting to become a load balancer][nginx-lb] alongside being a web
+server, which is pretty interesting, but HAProxy is still commonly used.
+
+First, grab the python file for the service you will be running from the
+[decal-labs repo][decal-labs-a7] using `wget` or something similar to download
+it. When run (`python3 server.py`), this script will start up 6 different HTTP
+server workers listening on ports 8080 to 8085 (inclusive). Each worker returns
+different content to make it clear which one your are talking to for this lab
+("Hello, I am ID 0" for instance), but in real usage they would generally all
+return the same content. You would still want something to distinguish between
+them (maybe a HTTP header saying which host or instance they are?), but only
+for debugging purposes, not like in this lab where they have actually differing
+content.
+
+The idea behind using a load balancer is that requests will be spread out among
+instances so that if a lot of requests are coming in all at once, they will not
+overload any one instance. Another very useful feature is that if one of the
+instances happens to crash or become unavailable for whatever reason, another
+working server will be used instead. This requires some kind of health checks
+to be implemented to decide whether a server is healthy or not.
+
+HAProxy has already been installed on your VM, but your job is to do the
+configuration to get it to work with the services you are given! The main
+config file is at `/etc/haproxy/haproxy.cfg` and you should only have to append
+to the end of this file to finish this lab. One snippet is provided here for you
+to add to the config already, this will give you a nice status page that you
+can use to see which of the servers is up or down:
+
+```
+listen stats
+  bind    0.0.0.0:7001
+  mode    http
+  stats   enable
+  stats   hide-version
+  stats   uri /stats
+```
+
+After adding this, if you restart the `haproxy` service and open
+`http://<username>.decal.xcf.sh:7001/stats` in a web browser, you should see a
+page with a table and some statistics information on HAProxy (pid, sessions,
+bytes transferred, uptime, etc.).
+
+#### Part 1: Configuration
+
+Your goal is to add a backend and frontend to haproxy's config that proxies to
+all of the running workers on the ports from 8080 to 8085 and listens on port
+7000 on your VM, so that if you go to `http://<username>.decal.xcf.sh:7000` you
+can see the responses from the workers. Try refreshing, what do you notice
+happening? Do you notice a pattern? What [load balancing algorithm][lb-algo]
+are you using from your observations? What config did you add to the haproxy
+config file to get this to work?
+
+#### Part 2: Health Checks
+
+Now, after adding all the servers to the backend in the config, add health
+checks for each of them. If you refresh the stats page, what do you notice has
+changed? What color are each of the servers in your backend?
+
+#### Part 3: Crashing
+
+If you make a request to `http://<username>.decal.xcf.sh:7000/crash`, it will
+crash the worker that you connect to. What changes in the HAProxy stats page?
+(Try refreshing a few times, the health checks can take a couple seconds to
+update the status from UP -> DOWN) If you make a lot of requests to
+`http://<username>.decal.xcf.sh:7000` again, are all the servers present in the
+IDs that are returned in your requests or not? Try crashing a particular worker
+by running `curl localhost:<port>/crash`, substituting the port with one of the
+workers that is still up on your instance. What happens on the HAProxy stats
+page? If you crash all the workers, what status code does HAProxy return to you
+when you make a request to the service?
+
+[nginx-lb]: https://docs.nginx.com/nginx/admin-guide/load-balancer/tcp-udp-load-balancer/
+[decal-labs-a7]: https://github.com/0xcf/decal-labs/blob/master/a7/server.py
+[lb-algo]: http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-balance
+
+
+### Extra Fun (optional questions)
 
 Once you have set up your DNS server, try changing your laptop's settings to
-use your VM as a DNS server and navigate to `http://example.com:5000` and you
-should see the toy service you set up in lab 6. Also try navigating to
+use your VM as a DNS server and navigate to `http://example.com:7000` and you
+should see the load-balanced services you set up. Also try navigating to
 `test.example.com`. What type of error do you see? Why do you think that this
 causes a error and does not display the page that http://example.com normally
 shows even though example.com resolves to the IP that you used
@@ -266,4 +331,4 @@ only accept queries from specific IP ranges that are more likely to be safe.
 **Again, the form for getting this lab checked off can be found
 [here][google-form].**
 
-[google-form]: https://goo.gl/forms/dAhp34bJaWXUM1U82
+[google-form]: https://goo.gl/forms/q3twPu4UWVVGwORS2

--- a/labs/a7.md
+++ b/labs/a7.md
@@ -185,9 +185,11 @@ seen yet in here, but you should at least recognize some of the options used.
 
 If you now run `dig ocf.berkeley.edu @localhost` from your VM, you should see
 that the command eventually times out after trying to run for about 15 seconds.
-The previous command failed because the DNS server was not started yet (Doh!).
-However, if `@localhost` is left off the end of the command, it succeeds. Why
-is this the case? What DNS server are requests currently being sent to?
+This is because it is trying to send DNS requests to your VM, but the DNS
+server is not actually running yet so it doesn't get a response. However, if
+`@localhost` is left off the end of the command, it succeeds. Why is this the
+case? What DNS server are requests currently being sent to if `@localhost` is
+not specified in the command?
 
 Try starting the DNS server using the relevant `systemctl` command. If you
 check the status of the `bind9` service after starting it, you should see the

--- a/labs/a7.md
+++ b/labs/a7.md
@@ -186,6 +186,9 @@ seen yet in here, but you should at least recognize some of the options used.
 If you now run `dig ocf.berkeley.edu @localhost` from your VM, you should see
 that the command eventually times out after trying to run for about 15 seconds.
 The previous command failed because the DNS server was not started yet (Doh!).
+However, if `@localhost` is left off the end of the command, it succeeds. Why
+is this the case? What DNS server are requests currently being sent to?
+
 Try starting the DNS server using the relevant `systemctl` command. If you
 check the status of the `bind9` service after starting it, you should see the
 status has changed to say that the service is active and running.


### PR DESCRIPTION
This is essentially the same as b7, but it has an extra section that covers load balancing with haproxy. Using a script from decal-labs (https://github.com/0xcf/decal-labs/pull/8) that starts up a number of workers, these workers can then be put into the haproxy config and have health checks added for each of them to show that haproxy can route around impaired instances, etc.

Ideally I think this lab would be completely different from b7 to allow people who have taken the basic/beginner track in the past to take the advanced one later and not have a bunch of overlapping material, but I think that's something to worry more about in future iterations. Thoughts?