### PR TITLE
Add check gh trust step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   stages {
     stage('check-gh-trust') {
       steps {
-        checkGitHubAccess(org: '0xcf')
+        checkGitHubAccess('0xcf')
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,12 @@ pipeline {
   }
 
   stages {
+    stage('check-gh-trust') {
+      steps {
+        checkGitHubAccess(org: '0xcf')
+      }
+    }
+
     stage('bundle') {
       steps {
         sh 'make bundle'


### PR DESCRIPTION
This checks that whoever makes a PR is a member of the 0xcf organization (or it prompts for approval to run). This could be a little bit annoying, but I think there's a pretty large security benefit to it overall if we can secure all the repos.