### PR TITLE
Use the decal email and channel for Jenkins alerts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,11 +42,11 @@ pipeline {
 
   post {
     failure {
-      emailNotification()
+      emailNotification('decal+jenkins@ocf.berkeley.edu')
     }
     always {
       node(label: 'slave') {
-        ircNotification()
+        ircNotification('#decal-spam')
       }
     }
   }


### PR DESCRIPTION
This redirects alerts for build failures to `decal+jenkins@ocf.berkeley.edu` and messages in IRC to `#decal-spam` from the default of `#rebuild-spam`.