### PR TITLE
Update lab a3

### DIFF
--- a/labs/a3.md
+++ b/labs/a3.md
@@ -78,14 +78,21 @@ sudo apt install --no-install-recommends qemu-kvm qemu-utils libvirt-bin virtins
 
 ### acquire installation media
 
-Next, we need to get the installation media. Download this, as well as
-a signature that we will use to verify the authenticity of the media,
-using the following commands:
+Next, we need to get the installation media. Go to
+https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/ to find the latest Arch
+release. Using the `wget` command within your VM, download the `.iso` file found
+within this directory as well as the `.iso.sig` signature file that we will use
+to verify the authenticity of the `.iso` file. For example, the current release
+at the time of writing is `2020.06.01`, so you would run the following commands:
 
 ```sh
-wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/2019.09.01/archlinux-2019.09.01-x86_64.iso'
-wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/2019.09.01/archlinux-2019.09.01-x86_64.iso.sig'
+wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/archlinux-2020.06.01-x86_64.iso'
+wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/archlinux-2020.06.01-x86_64.iso.sig'
 ```
+Note that the Arch distribution is updated relatively frequently, so the links
+used above are likely out of date by the time you're reading this! Make sure to
+find the correct files for the latest release, do not just copy and paste the
+commands above.
 
 You can run `ls` to see the two files that were downloaded.
 
@@ -204,9 +211,9 @@ either of them reach it?
 
 ## partitioning time
 
-The first order of business is to set up the partitions that we will
-be using for this installation. We are going to use a simple parition
-scheme:
+The first order of business is to set up the
+[partitions](https://en.wikipedia.org/wiki/Disk_partitioning) that we will be
+using for this installation. We are going to use a simple partition scheme:
 - an EFI system partition (ESP)
 - one encrypted partition that holds our root filesystem
 - a small partition for swap space
@@ -215,21 +222,38 @@ This is a very common scheme and is totally a scheme you could use if
 you were installing Arch on your own computer (except that you'll
 hopefully have more than 5GiB to work with)!
 
+**GRADESCOPE**: Give a brief and basic explanation of the purpose of having (1)
+the EFI system partition and (2) the swap partition. These explanations can be
+as short as one sentence, just try to get a general sense of why we have these
+partitions.
+
 ### create partitions
 
-We will use `fdisk` to create our partitions. Run `fdisk /dev/sda` to start.
+We will use `fdisk` to create our partitions. Before we start the actual
+partitioning process, run `fdisk -l`. You should see that your VM has a single
+storage device called `/dev/sda`. Linux has special [device
+files](https://wiki.archlinux.org/index.php/Device_file) that correspond to each
+"block device" (e.g. hard drives, SSDs, and partitions on the aformentioned
+storage devices) discovered by the operating system. These device files live in
+the `/dev` folder. Read more about the naming convention for storage devices and
+their partitions
+[here](https://wiki.archlinux.org/index.php/Device_file#Block_device_names).
 
-> Note that you'll be making a bunch of changes to the parition table,
-> but these changes are not made immediately. So, if you make a
-> mistake, you can just start again from step 1 without damaging
-> anything.
+> Test your understanding: What would be the name of the device file
+> corresponding to the fourth partition on the second discovered storage device?
+
+Now to start the actual partitioning process, run `fdisk /dev/sda`.
+
+> Note that you'll be making a bunch of changes to the partition table, but
+> these changes are not made immediately. So, if you make a mistake, you can
+> just start again from step 1 without damaging anything.
 
 1. Create a GPT table by typing `g` (then hit enter).
-2. Create your ESP by typing `n`. Use the default parition number and
+2. Create your ESP by typing `n`. Use the default partition number and
    first sector (just hit enter to automatically take the default).
    For the last sector, type `+512M` to allocate 512MiB for the
    partition.
-3. Type `t` to change the type of the new partition (parition 1) to
+3. Type `t` to change the type of the new partition (partition 1) to
    "EFI System". You will have to list the types and find the right
    ID. (Note: press `q` to get out of the list of filesystem types).
 4. Create your main root partition by typing `n` again. Use the
@@ -239,7 +263,7 @@ We will use `fdisk` to create our partitions. Run `fdisk /dev/sda` to start.
    "Linux filesystem", so you won't need to change that.)
 5. Create your swap partition by typing `n` one last time, and just
    take all the defaults.
-6. Type `t` to change the type of the swap partition (parition 3) to
+6. Type `t` to change the type of the swap partition (partition 3) to
    "Linux swap", as in step 3.
 7. Type `p` to show the current partition table with all the changes
    you've made. You should see an "EFI System" partition that is
@@ -343,7 +367,7 @@ Paste this output into Gradescope!
 
 We now have a blank pseudo-partition ("block device")
 `/dev/mapper/cryptroot`, that's actually backed by encrypted
-`/dev/sda2` disk parition. However, there's no filesystem here
+`/dev/sda2` disk partition. However, there's no filesystem here
 yet. Create it by doing
 
 ```sh
@@ -379,11 +403,25 @@ swapon /dev/sda3
 ### mount the new filesystems
 
 We've now created all our filesystems, but in order to access them, we
-need to mount them. We're going to use `/mnt` as the temporary root of
-the new Arch installation. Thus, we mount the root filesystem at
-`/mnt`, and the ESP at `/mnt/boot` (since the ESP will normally be
-mounted at `/boot`). Hopefully this will make a little more sense once
-we begin installing the system.
+need to mount them.
+
+> What does mounting mean? The `man` page for the `mount` command provides a
+> nice description: "All files accessible in a Unix system are arranged in one
+> big tree, the file hierarchy, rooted at /. These files can be spread out over
+> several devices. The mount command serves to attach the filesystem found on
+> some device to the big file tree. Conversely, the umount(8) command will
+> detach it again." We are currently in the "file tree" of the Arch live
+> environment, which does not include the new ESP and root filesystems we
+> created for our future Arch installation. Using `mount`, we can attach these
+> filesystems to our live environment filesystem and access them as if they were
+> directories at the mount point. Once the ESP and root filesystems are visible
+> to the current filesystem, we can start installing a boot loader to the ESP
+> filesystem and our permanent Arch OS to the root filesystem.
+
+We're going to use `/mnt` as the temporary root of the new Arch installation.
+Thus, we mount the root filesystem at `/mnt`, and the ESP at `/mnt/boot` (since
+the ESP will normally be mounted at `/boot`). Hopefully this will make a little
+more sense once we begin installing the system.
 
 ```sh
 mount /dev/mapper/cryptroot /mnt
@@ -391,9 +429,21 @@ mkdir /mnt/boot
 mount /dev/sda1 /mnt/boot
 ```
 
-**GRADESCOPE**: You can see every single filesystem that's currently
-mounted by running the `mount` command. Run it, and look for the two
-filesystems we just mounted. Copy all the output over to Gradescope.
+**GRADESCOPE**:
+
+1. You can see every single filesystem that's currently mounted by running the
+   `mount` command. Run it, and look for the two filesystems we just mounted.
+   Copy all the output over to Gradescope.
+
+2. Another common Linux partitioning scheme is to have a separate `/home`
+   partition in addition to the partitions we created above. This can be useful
+   in case something goes catastrophically wrong with your operating system to
+   the point where you need to reinstall it. You can wipe your root filesystem
+   and reinstall your OS while leaving your `/home` partition untouched, saving
+   your user folder(s) with personal files like documents and photos without
+   needing to restore from a backup. Hypothetically, if we had made a separate
+   `/home` partition and filesystem in the previous steps, what command(s) would
+   we need to run to mount it? Assume the `/home` partition is `/dev/sda3`.
 
 ## Installation
 
@@ -423,9 +473,9 @@ make things a bit faster to install.)
 ### continue according to ArchWiki!
 
 Follow the arch wiki exactly from
-[https://wiki.archlinux.org/index.php/Installation_guide#Install_the_base_packages](https://wiki.archlinux.org/index.php/Installation_guide#Install_the_base_packages)
-down until you get to the "Initramfs" section. If you get stuck, check
-out the following hints:
+[https://wiki.archlinux.org/index.php/Installation_guide#Install_essential_packages](https://wiki.archlinux.org/index.php/Installation_guide#Install_essential_packages)
+down until you get to the "Initramfs" section. If you get stuck, check out the
+following hints:
 
 - `vim` is not installed in the chroot by default. You can do
   `pacman -S vim` to install it, or just use plain old `vi`.
@@ -477,9 +527,10 @@ Use `passwd` to set the root password to `itoolovelinux`.
 
 ### boot loader
 
-Historically, GRUB has been the only reasonable choice of boot
-loader. However, with the advent of UEFI, there are lots of different
-good options (or my personal favorite, no bootloader at all). In this
+Historically, GRUB has been the only reasonable choice of boot loader. However,
+with the advent of UEFI, there are lots of different good options (or my
+personal favorite, [no bootloader at
+all](https://wiki.archlinux.org/index.php/EFISTUB#Using_UEFI_directly)). In this
 lab, we are going to use
 [systemd-boot](https://wiki.archlinux.org/index.php/Systemd-boot).
 
@@ -522,7 +573,7 @@ can mess things up pretty bad! TRIPLE-CHECK this file!**
 > booted the archiso? We can add that option here to make it permanent
 > for the new system, so the console will always be enabled.
 
-Type `exit` to exit the chroot and then type `reboot** to REBOOT AND
+Type `exit` to exit the chroot and then type `reboot` to REBOOT AND
 FINISH THE INSTALLATION! Congrats!
 
 > If things don't work after you reboot, don't panic! Please make a

--- a/labs/a3.md
+++ b/labs/a3.md
@@ -30,7 +30,7 @@ later in the lab.
 > usually be applied to other distributions as well. Third,
 > ArchWiki. Seriously. It's that good.
 
-## setup
+## Setup
 
 We will be setting up virtual machine _inside_ your student VM.
 
@@ -76,7 +76,7 @@ sudo apt install --no-install-recommends qemu-kvm qemu-utils libvirt-bin virtins
 > [UEFI](https://wiki.archlinux.org/index.php/Unified_Extensible_Firmware_Interface)
 > (instead of the older BIOS spec) to boot the VM.
 
-### acquire installation media
+### Acquire installation media
 
 Next, we need to get the installation media. Go to
 https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/ to find the latest Arch
@@ -132,7 +132,7 @@ what is their key's fingerprint?
 > solutions to this fundamental problem of "How do I know you are who
 > you say you are?"
 
-### create VM
+### Create VM
 
 Now, we need to actually create our VM. _(Don't run this command until
 you've read the next paragraph!)_ To do this, you will run
@@ -212,7 +212,7 @@ either of them reach it?
 > that we've conveniently inherited the system clock, so the time
 > inside the VM should be right. You can run `date` to see.
 
-## partitioning time
+## Partitioning time
 
 The first order of business is to set up the
 [partitions](https://en.wikipedia.org/wiki/Disk_partitioning) that we will be
@@ -230,7 +230,7 @@ the EFI system partition and (2) the swap partition. These explanations can be
 as short as one sentence, just try to get a general sense of why we have these
 partitions.
 
-### create partitions
+### Create partitions
 
 We will use [`fdisk`](https://wiki.archlinux.org/index.php/Fdisk) to create our
 partitions. Before we start the actual partitioning process, run `fdisk -l`. You
@@ -284,7 +284,7 @@ At this point, you've created the disk partitions, but nothing is on
 them yet. Now we need to put the filesystems you will use on these
 partitions!
 
-### create filesystems
+### Create filesystems
 
 #### ESP
 
@@ -299,7 +299,7 @@ FAT32 filesystem.
 > These instructions are straight from
 > [https://wiki.archlinux.org/index.php/EFI_system_partition#Format_the_partition](https://wiki.archlinux.org/index.php/EFI_system_partition#Format_the_partition).
 
-#### root partition
+#### Root partition
 
 Our root partition should be `/dev/sda2`.
 
@@ -313,7 +313,7 @@ more complicated, but thankfully the ArchWiki will help us out!
 > encryption, you will not be able to get anything off the disk at all
 > without the encryption password.
 
-##### wiping
+##### Wiping
 
 Before setting up the encrypted partition, we need to wipe the
 partition with random data. The instructions below are based on
@@ -336,7 +336,7 @@ cryptsetup close to_be_wiped
 > (indistinguishable from random data). This might take a sec to do!
 > Don't worry.
 
-##### setting up the encrypted device
+##### Setting up the encrypted device
 
 Again, this is taken from the ArchWiki. [Follow
 along!](https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_an_entire_system#LUKS_on_a_partition)
@@ -366,7 +366,7 @@ cryptsetup open /dev/sda2 cryptroot
 **GRADESCOPE**: Run `lsblk` to see the hierarchy of these partitions.
 Paste this output into Gradescope!
 
-##### creating the actual filesystem
+##### Creating the actual filesystem
 
 We now have a blank pseudo-partition ("block device")
 `/dev/mapper/cryptroot`, that's actually backed by encrypted
@@ -380,7 +380,7 @@ mkfs.ext4 /dev/mapper/cryptroot
 **GRADESCOPE**: What previous command we ran is similar to this
 command, and what's the difference? (Bonus: why?)
 
-#### swap
+#### Swap
 
 Our swap partition should be `/dev/sda3`. The swap space isn't really
 a _filesystem_, but we still need to set it up. Thankfully, this is
@@ -403,7 +403,7 @@ swapon /dev/sda3
 > [https://wiki.archlinux.org/index.php/Swap](https://wiki.archlinux.org/index.php/Swap).
 
 
-### mount the new filesystems
+### Mount the new filesystems
 
 We've now created all our filesystems, but in order to access them, we
 need to mount them.
@@ -459,7 +459,7 @@ installing out system onto them!
 > It's a good idea to follow along there as well to see what
 > modifications we are making.
 
-### mirrors
+### Mirrors
 
 We need to tell Arch which software mirror to use when downloading
 packages. Go ahead and just put the OCF mirror at the top! Edit
@@ -473,7 +473,7 @@ Server = https://mirrors.ocf.berkeley.edu/archlinux/$repo/os/$arch
 (We're usually lower down in the file but putting us at the top will
 make things a bit faster to install.)
 
-### continue according to ArchWiki!
+### Continue according to ArchWiki!
 
 Follow the arch wiki exactly from
 [https://wiki.archlinux.org/index.php/Installation_guide#Install_essential_packages](https://wiki.archlinux.org/index.php/Installation_guide#Install_essential_packages)
@@ -517,7 +517,7 @@ The _order_ of these hooks matters! Be careful.
 Run `mkinitcpio -p linux` to generate the new initramfs based on the
 new config file.
 
-### root password
+### Root password
 
 Use `passwd` to set the root password to `itoolovelinux`.
 
@@ -528,7 +528,7 @@ Use `passwd` to set the root password to `itoolovelinux`.
 > (which should generally be untrusted) to access everything on your
 > computer.
 
-### boot loader
+### Boot loader
 
 Historically, GRUB has been the only reasonable choice of boot loader. However,
 with the advent of UEFI, there are lots of different good options (or my

--- a/labs/a3.md
+++ b/labs/a3.md
@@ -89,10 +89,13 @@ at the time of writing is `2020.06.01`, so you would run the following commands:
 wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/archlinux-2020.06.01-x86_64.iso'
 wget 'https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/archlinux-2020.06.01-x86_64.iso.sig'
 ```
-Note that the Arch distribution is updated relatively frequently, so the links
-used above are likely out of date by the time you're reading this! Make sure to
-find the correct files for the latest release, do not just copy and paste the
-commands above.
+Note that Arch is a ["rolling
+release"](https://en.wikipedia.org/wiki/Rolling_release) distribution (as
+opposed to distros like Ubuntu that release distinct versions e.g. Ubuntu 18.04,
+Ubuntu 20.04), so it is updated frequently. Therefore, the links used above are
+likely out of date by the time you're reading this! Make sure to find the
+correct files for the latest release, do not just copy and paste the commands
+above.
 
 You can run `ls` to see the two files that were downloaded.
 
@@ -229,14 +232,14 @@ partitions.
 
 ### create partitions
 
-We will use `fdisk` to create our partitions. Before we start the actual
-partitioning process, run `fdisk -l`. You should see that your VM has a single
-storage device called `/dev/sda`. Linux has special [device
-files](https://wiki.archlinux.org/index.php/Device_file) that correspond to each
-"block device" (e.g. hard drives, SSDs, and partitions on the aformentioned
-storage devices) discovered by the operating system. These device files live in
-the `/dev` folder. Read more about the naming convention for storage devices and
-their partitions
+We will use [`fdisk`](https://wiki.archlinux.org/index.php/Fdisk) to create our
+partitions. Before we start the actual partitioning process, run `fdisk -l`. You
+should see that your VM has a single storage device called `/dev/sda`. Linux has
+special [device files](https://wiki.archlinux.org/index.php/Device_file) that
+correspond to each "block device" (e.g. hard drives, SSDs, and partitions on the
+aformentioned storage devices) discovered by the operating system. These device
+files live in the `/dev` folder. Read more about the naming convention for
+storage devices and their partitions
 [here](https://wiki.archlinux.org/index.php/Device_file#Block_device_names).
 
 > Test your understanding: What would be the name of the device file


### PR DESCRIPTION
Resolves #183 

Changes

- Update mirrors and Arch Wiki links

- Partitioning section: add device naming convention, Gradescope question, correct "parition" typos

- Mounting section: add mount explanation, Gradescope question

This is a relatively small update to cooperc's Arch install lab; I initially wanted to reduce the instructions and make it more self-guided but I realized there's quite a lot of stuff that can go wrong and make the lab frustrating if it was less structured. I've added some explanations and Gradescope questions to test understanding at points where they felt relevant. I edited this lab without actually doing an Arch install while going through it, so we should probably do a run through on an actual DO droplet to see if there are any parts that people might have trouble with.

As for making a less structured Arch installation lab, I think it would be better to just add an optional section at the end to do your own Arch installation in Virtualbox on a personal machine while following the official Arch Wiki installation guide. It could include some extra direction on tailoring an Arch install for personal use, like different partitioning schemes, LVM, installing a window manager/desktop environment, etc.