### PR TITLE
Lab a3 Fixes

### DIFF
--- a/labs/a3.md
+++ b/labs/a3.md
@@ -123,6 +123,10 @@ Key". You'll see a bunch of info about their PGP key. Check that the
 key fingerprint" in the `gpg` output. If not, something is very
 wrong!
 
+> If the `gpg` commmand above to verify the signature doesn't work,
+> try using the OCF's keyserver by appending this to the original
+> command: `--keyserver=hkp://pgp.ocf.berkeley.edu`.
+
 **GRADESCOPE**: Who is the developer that created this signature, and
 what is their key's fingerprint?
 
@@ -137,11 +141,11 @@ what is their key's fingerprint?
 
 ### Create VM
 
-Now, we need to actually create our VM. _(Don't run this command until
-you've read the next paragraph!)_ To do this, you will run
+Now, we need to actually create our VM. **_(Don't run this command
+until you've read the next paragraph!)_** To do this, you will run
 
 ```sh
-sudo virt-install --name archvm --memory 512 --cpu host --vcpus 1 --disk size=5 --network network=default --boot uefi --graphics none --cdrom archlinux-2019.09.01-x86_64.iso
+sudo virt-install --name archvm --memory 704 --cpu host --vcpus 1 --disk size=5 --network network=default --boot uefi --graphics none --cdrom archlinux-2019.09.01-x86_64.iso
 ```
 
 This will do some initial setup, and then drop us into a virtual


### PR DESCRIPTION
Some instructions are slightly broken since the lab was initially written. Should've done a run-through beforehand, my bad.

---

Fix installation media and VM setup instructions

- Add note to try OCF keyserver if gpg command fails

- Bold warning at the beginning of Create VM section

- Increase virt-install memory flag to 704MB