### PR TITLE
Add warning to upgrade/reboot DO droplet

### DIFF
--- a/labs/a3.md
+++ b/labs/a3.md
@@ -6,6 +6,19 @@ layout: lab
 * Navigation
 {:toc}
 
+> **PLEASE READ**: Some people have been having issues with the Create
+> Filesystems -> Wiping section of the lab, where executing the
+> commands causes the Arch VM to reboot into the UEFI shell. To avoid
+> encountering this problem, please upgrade packages/reboot Ubuntu on
+> your Digital Ocean droplet if prompted to do so by the motd (Message
+> of the Day; the text you see when you `ssh` into your DO droplet).
+> In other words, before starting the lab, run `sudo apt update`, then
+> `sudo apt upgrade`, and finally `sudo reboot`. You will lose
+> connection when your DO droplet reboots, then `ssh` back in and
+> begin the lab. If you are already in the middle of the lab, you can
+> try to proceed through the Wiping section, but if you run into the
+> issue you will likely need to destroy and start a fresh VM.
+
 In this lab we will be installing Arch Linux into a virtual machine.
 In this lab you will need to pay close attention to detail: mistakes
 may not be apparent for quite a while later, and can cause _huge_

--- a/labs/a3.md
+++ b/labs/a3.md
@@ -11,13 +11,15 @@ layout: lab
 > commands causes the Arch VM to reboot into the UEFI shell. To avoid
 > encountering this problem, please upgrade packages/reboot Ubuntu on
 > your Digital Ocean droplet if prompted to do so by the motd (Message
-> of the Day; the text you see when you `ssh` into your DO droplet).
-> In other words, before starting the lab, run `sudo apt update`, then
-> `sudo apt upgrade`, and finally `sudo reboot`. You will lose
-> connection when your DO droplet reboots, then `ssh` back in and
-> begin the lab. If you are already in the middle of the lab, you can
-> try to proceed through the Wiping section, but if you run into the
-> issue you will likely need to destroy and start a fresh VM.
+> of the Day; the text you see when you `ssh` into your DO droplet),
+> but **do not upgrade to Ubuntu 20.04 (do not run the command
+> `do-release-upgrade`)**. In other words, before starting the lab,
+> run `sudo apt update`, then `sudo apt upgrade`, and finally `sudo
+> reboot`. You will lose connection when your DO droplet reboots, then
+> `ssh` back in and begin the lab. If you are already in the middle of
+> the lab, you can try to proceed through the Wiping section, but if
+> you run into the issue you will likely need to destroy and start a
+> fresh VM.
 
 In this lab we will be installing Arch Linux into a virtual machine.
 In this lab you will need to pay close attention to detail: mistakes


### PR DESCRIPTION
Some people were having issues during lab a3 where executing the commands in the Create Filesystems --> Wiping section would cause the Arch VM to reboot into the UEFI shell. According to people troubleshooting on Slack, this issue was resolved by following the DO droplet's motd prompting the user to upgrade packages and reboot the droplet. Not sure why this behavior manifests, as I don't think using older packages should have affected the lab. I've added a note at the top of the lab to upgrade and reboot before attempting the lab.