### PR TITLE
Lab a4 link fix

### DIFF
--- a/labs/a4.md
+++ b/labs/a4.md
@@ -22,12 +22,12 @@ lecture.
    * Red Hat [documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/chap-security-enhanced_linux-introduction)
    * [Wikipedia (obviously)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux)
 2. Managing users and groups
-   * [TLDP](http://www.tldp.org/LDP/GNU-Linux-Tools-Summary/html/c6239.htm) entry
+   * [TLDP](https://www.tldp.org/LDP/GNU-Linux-Tools-Summary/html/c6239.htm) entry
    * An excellent DigitalOcean [guide](https://www.digitalocean.com/community/tutorials/how-to-view-system-users-in-linux-on-ubuntu)
    * These great [StackExchange](https://unix.stackexchange.com/questions/74809/is-it-possible-to-hide-an-account-from-etc-passwd/74898#74898) answers
    * ArchWiki [breakdown](https://wiki.archlinux.org/index.php/File_permissions_and_attributes) of permissions
    * Debian Wiki [equivalent](https://wiki.debian.org/Permissions)
-   * If you [needed](http://www.zdnet.com/article/show-stopping-bug-appears-in-npm-node-js-package-manager/) more [reasons](https://github.com/npm/npm/issues/19883) to be skeptical of the maturity of the Node ecosystem
+   * If you [needed](https://www.zdnet.com/article/show-stopping-bug-appears-in-npm-node-js-package-manager/) more [reasons](https://github.com/npm/npm/issues/19883) to be skeptical of the maturity of the Node ecosystem
    * [Protection Rings](https://en.wikipedia.org/wiki/Protection_ring) - no DND, unfortunately
    * [glibc](https://code.woboq.org/userspace/glibc/sysdeps/unix/sysv/linux/faccessat.c.html) and 
      [kernel](https://elixir.bootlin.com/linux/latest/source/fs/open.c#L353) source where some of this stuff gets checked
@@ -146,7 +146,7 @@ DeCal VM, and load up a few tunes.
 GitHub is a good place to host your source code, but self-hosting your own Git
 can be a good option if you need to store something private (and don’t trust GitHub),
 hosting your own can be a good solution. While you can use Git to host a repo on any
-SSH server using a [bare repo](http://www.saintsjd.com/2011/01/what-is-a-bare-git-repository/),
+SSH server using a [bare repo](https://www.saintsjd.com/2011/01/what-is-a-bare-git-repository/),
 to get a fancy GUI you need to install special software. Some popular options
 for this include [Gitea](https://gitea.io/en-us/) (which mimicks GitHub’s interface)
 and [cgit](https://git.zx2c4.com/cgit/about/) (which takes a more minimalist approach).

--- a/labs/a4.md
+++ b/labs/a4.md
@@ -18,7 +18,7 @@ lecture.
    facilities. Utilizing it is well beyind the scope of this class, but reading
    about how SELinux works should give you an appreciation for the degree to
    which people have thought about file-level security in the kernel.
-   * [Official Wiki](selinunxproject.org) 
+   * [Official Wiki](https://selinunxproject.org) 
    * Red Hat [documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/chap-security-enhanced_linux-introduction)
    * [Wikipedia (obviously)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux)
 2. Managing users and groups

--- a/labs/a4.md
+++ b/labs/a4.md
@@ -18,7 +18,7 @@ lecture.
    facilities. Utilizing it is well beyind the scope of this class, but reading
    about how SELinux works should give you an appreciation for the degree to
    which people have thought about file-level security in the kernel.
-   * [Official Wiki](https://selinunxproject.org) 
+   * [Official Wiki](https://selinuxproject.org/)
    * Red Hat [documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/chap-security-enhanced_linux-introduction)
    * [Wikipedia (obviously)](https://en.wikipedia.org/wiki/Security-Enhanced_Linux)
 2. Managing users and groups


### PR DESCRIPTION
- fix link to selinuxproject.org, otherwise it jumps to https://decal.ocf.berkeley.edu/labs/selinunxproject.org
- change http links to https
