### PR TITLE
Fixes to a7 spec

### DIFF
--- a/labs/a7.md
+++ b/labs/a7.md
@@ -109,16 +109,19 @@ To submit the lab, answer the questions on Gradescope.
 
 ## NFS
 
-We have provided a NFS server for you to connect to at `staff` with two
-different directories, one read-only and one read-write. First install the
-`nfs-common` package so that you can mount directories over NFS. Then, use the
-`mount` command (remember to look at the `man` pages or search online if you do
-not recognize a command) to mount from `staff:/opt/lab7/public` (the remote
-directory) to your local directory at `/opt/lab7/read-only`. Once you do this,
+We have provided a NFS server for you to connect to at `staff4.decal.xcf.sh` with two
+different directories, one read-only and one read-write. 
+
+First, **install the `nfs-common` package** so that you can mount directories over NFS. 
+Then, **use the `mount` command** (remember to look at the `man` pages or search online if you do
+not recognize a command) to mount from `staff4.decal.xcf.sh:/opt/lab7/public` (the remote
+directory) to your local directory at `/mnt/`. Once you do this,
 you should see a file with a secret inside it in `/opt/lab7/read-only`. You can
 tell if you are connected or not by running `df` and checking if there is
-something that looks like `staff:/opt/lab7/public` present in the list. What is
-the secret in the file? If NFS takes a excessive time to mount or you cannot
+something that looks like `staff4.decal.xcf.sh:/opt/lab7/public` present in the list. What is
+the secret in the file? 
+
+If NFS takes a excessive time to mount or you cannot
 read the file because it hangs while doing so, please let us know. Try creating
 a file in the read-only directory (note that you will want to try with `sudo`,
 otherwise you will get a permission denied error because `root` owns the
@@ -131,14 +134,17 @@ loaded and you will get an error message like `umount.nfs4:
 NFS. If you run `df`, you should see that the entry that was present before has
 now disappeared.
 
-Next, mount the directory at `staff:/opt/lab7/private/<your username>` to
-`/opt/lab7/read-write` using `mount` in a similar way to before. What do you
-see in `/opt/lab7/read-write` now? Follow the instructions in the file given
-there, note that you will have to use `sudo` here too to create a new file
+Now, let's unmount the filesystem using `umount /mnt/` so that we can mount
+a different directory, at `staff4.decal.xcf.sh:/opt/lab7/private/<your username>`
+using `mount` in a similar way to before. What do you
+see in `/mnt/` now? 
+
+Follow the instructions in the file given
+there. note that you will have to use `sudo` here too to create a new file
 since the directory mounted over NFS is owned by root, not your user.
 
 Again, if NFS takes an excessive time to mount during any of this or you cannot
-read files because it hands while doing so, please let us know on Piazza or by
+read files because it hands while doing so, please let us know on Slack or by
 email (or at office hours if you'd prefer). We've had some problems in the past
 with NFS being very slow to mount/read and needing a restart.
 
@@ -166,13 +172,16 @@ more information.
 
 [lab-a5]: /labs/a5#dns-configuration
 
-First, install the `bind9` package on your VM to set up a DNS server. By
-default, the service is not running yet. What is the `systemctl` command to
-show if the `bind9` service is running or not?
+First, install the `bind9` package on your VM to set up a DNS server.
+
+Let's check the status of the service using `systemctl`. **What command can you run to do this?**
 
 In the output of the `systemctl` command, you should see that the `bind9`
-service is not running (yet) and has a unit file at
-`/lib/systemd/system/bind9.service`. If you print that file, you should see
+service is already running. Let's bring it down temporarily so we can
+investigate: `systemctl stop bind9`
+
+The service should have a unit file at
+`/lib/systemd/system/named.service`. If you print that file, you should see
 something like this:
 
 ```
@@ -231,9 +240,14 @@ Then, create a file `/etc/bind/db.example.com` to contain the responses to give
 if anyone sends requests to your DNS server for `example.com`. The easiest way
 to do this is generally to copy an existing config and then make changes from
 there to get what you want for your config instead of having to start from
-scratch. To make this easier, we've provided a valid config at
-`/opt/lab7/db.example.com` that you can copy in place at
-`/etc/bind/db.example.com`. It is prefilled with your VM's IP, and includes a
+scratch. 
+
+To make this easier, we've provided a valid config in 
+[decal-labs](https://github.com/0xcf/decal-labs/blob/master/a7/db.example.com)
+that you can copy in place at
+`/etc/bind/db.example.com`. **You'll need to edit the config to include your VM's IP address!**
+
+This config includes a
 subdomain that does not usually exist, named `test.example.com`. Please add few
 more records of your choice. Try to add one A record, and a couple of other
 types of records (CNAME, SRV, TXT, etc.).  Make sure to reload the `bind9`
@@ -244,9 +258,6 @@ If you now run the `dig` commands below, you should see that your VM's domain
 name (`<username>.decal.xcf.sh`) is returned for the first result, for the
 second result (`example.com`) your VM's IP address should be returned, and for
 `test.example.com` you should see `93.184.216.34` as the result.
-
-What commands did you use to query for each of the records (including the ones
-you added)?
 
 Make sure to run these commands from your VM, or if you want to run them from
 your laptop or from an OCF computer, substitute `localhost` in any commands
@@ -269,9 +280,13 @@ commonly-used open-source load balancer. [NGINX](https://nginx.org/) is
 actually [starting to become a load balancer][nginx-lb] alongside being a web
 server, which is pretty interesting, but HAProxy is still commonly used.
 
+You can install HAProxy using `apt install haproxy`.
+
 First, grab the python file for the service you will be running from the
 [decal-labs repo][decal-labs-a7] using `wget` or something similar to download
-it. When run (`python3 server.py`), this script will start up 6 different HTTP
+it. You'll likely also need to install `tornado` using `apt install python3-tornado`.
+
+When run (`python3 server.py`), this script will start up 6 different HTTP
 server workers listening on ports 8080 to 8085 (inclusive). Each worker returns
 different content to make it clear which one your are talking to for this lab
 ("Hello, I am ID 0" for instance), but in real usage they would generally all
@@ -287,8 +302,7 @@ instances happens to crash or become unavailable for whatever reason, another
 working server will be used instead. This requires some kind of health checks
 to be implemented to decide whether a server is healthy or not.
 
-HAProxy has already been installed on your VM, but your job is to do the
-configuration to get it to work with the services you are given! The main
+Your job is to do the configuration to get it to work with the services you are given! The main
 config file is at `/etc/haproxy/haproxy.cfg` and you should only have to append
 to the end of this file to finish this lab. One snippet is provided here for you
 to add to the config already, this will give you a nice status page that you


### PR DESCRIPTION
 - change /opt/lab7/readonly,readwrite to mnt
 - Piazza delete
 - DNS: instruct students to intentionally bring down bind9
 - Change location of bind9.service to /lib/systemd/system/named.service
 - Link to named.conf.local  in decal-labs
 - Instructions to install HAProxy
 - Install tornado using apt install python3-tornado