### PR TITLE
a7: fix bind9 systemd unit file info

### DIFF
--- a/labs/a7.md
+++ b/labs/a7.md
@@ -193,13 +193,14 @@ Wants=nss-lookup.target
 Before=nss-lookup.target
 
 [Service]
-EnvironmentFile=/etc/default/bind9
+EnvironmentFile=-/etc/default/named
 ExecStart=/usr/sbin/named -f $OPTIONS
 ExecReload=/usr/sbin/rndc reload
 ExecStop=/usr/sbin/rndc stop
 
 [Install]
 WantedBy=multi-user.target
+Alias=bind9.service
 ```
 
 This should look pretty familiar to you after the lecture on services! Don't

--- a/labs/a7.md
+++ b/labs/a7.md
@@ -180,9 +180,9 @@ In the output of the `systemctl` command, you should see that the `bind9`
 service is already running. Let's bring it down temporarily so we can
 investigate: `systemctl stop bind9`
 
-The service should have a unit file at
-`/lib/systemd/system/named.service`. If you print that file, you should see
-something like this:
+The service should have a unit file at `/lib/systemd/system/named.service` or
+`/lib/systemd/system/bind9.service`. If you print that file (with `cat` or
+`systemctl cat bind9`), you should see something like this:
 
 ```
 [Unit]


### PR DESCRIPTION
In Ubuntu 18.04, `bind9.service` is at `/lib/systemd/system/bind9.service`, but in 20.04, it's at `/lib/systemd/system/named.service`.

See https://packages.ubuntu.com/bionic/amd64/bind9/filelist (18.04LTS) and https://packages.ubuntu.com/focal/amd64/bind9/filelist (20.04LTS) and search for `.service` for the current package content.

The more reliable way of cat that file should be `systemctl cat bind9`. Because on Ubuntu 20.04 `bind9.service` is an alias to `named.service`, it works on both releases.