### PR TITLE
Started updating a9

### DIFF
--- a/labs/a9.md
+++ b/labs/a9.md
@@ -10,8 +10,10 @@ layout: lab
 This lab is a bit unique compared to the rest, very little programming is
 involved. 
 
-In this lab, we will briefly cover a variety of topics that are of interest to
-those studying computer security.
+In this lab, we will cover a variety of topics that are of interest to
+those studying computer security. We will go much more in depth than you
+need to know, so we hope you pick up the main practical concepts and dig
+deeper if you are interested.
 
 There are many aspects to security, and the field spans a number of
 disciplines. We will cover the following:
@@ -24,11 +26,9 @@ disciplines. We will cover the following:
 * File Security
 * Network Security
 
-<!-- TODO: When a facilitator is determined for this lab, remember to put their Slack username here! -->
 ## Getting help
 If you want any help with any part of this lab, join the OCF slack
-(<https://ocf.io/slack>), and post your questions in
- **#decal-general**.
+(<https://ocf.io/slack>), and post your questions in **#decal-general**.
 
 # Threat Models
 
@@ -52,7 +52,8 @@ few axioms, covered very well in the first [lecture note][cs161_1] of CS 161
 5. How many resources should you devote to protecting it?
 
 ### Example: Safekeeping
-Let's say that you run a safe storage facility for customers to store a variety of valuables. **Here's a description of what your threat model might look like:**
+Let's say that you run a safe storage facility for customers to store a variety
+of valuables. **Here's a description of what your threat model might look like:**
 
 In this scenario, you're responsible for your clients' valuables. There are a
 multitude of adversaries, including burglars ranging from smash-and-grab to more
@@ -74,8 +75,9 @@ fradulent clients.
 
 ### Task 1: Construct your own threat model
 You're a journalist criticizing the local authoritarian government and trying to
-get your story to ProPublica. Considering the principles of security and the above questions, describe your threat model and how you would
-safely deliver the information.
+get your story to ProPublica. Considering the principles of security and the 
+above questions, describe your threat model and how you would safely deliver the
+information.
 
 
 # Security Building Blocks
@@ -107,7 +109,7 @@ today.
 For the purpose of this lab, we will be using several tools for performing
 encryption operations, among them **GnuPG**, a free implementation of the
 [OpenPGP](https://openpgp.org/) standard, and
-[**OpenSSL**](https://openssl.com), a library for implementing TLS, or
+[**OpenSSL**](https://openssl.org), a library for implementing TLS, or
 Transport Layer Security.
 
 #### Symmetric Key Cryptography
@@ -206,19 +208,26 @@ including signatures and certificates for digital identity verification.
 Suppose you are an important public entity (maybe your pseudonym is Natoshi
 Sakamoto). You are in charge of an important project, hereafter known at
 Litcoin. You'd like to maintain anonymity, but still need to lead your project.
+
 How can your loyal followers know that statements supposedly made by Natoshi
-Sakamoto are actually from you? There's a significant incentive to make false
+Sakamoto are actually from you?
+
+There's a significant incentive to make false
 statements supposedly "from" Mr. Sakamoto, because each Litcoin is apparently
 worth a significant amount of real money, and some people stand to gain
 substantially if they are able to influence the direction of the project in
-their favor. You can avoid this by signing your messages: in the beginning, you
+their favor.
+
+You can avoid this by signing your messages: in the beginning, you
 would publish Natoshi's public key, and thereafter, for every post you make, you
 would encrypt the content of the message using your (Natoshi's) private key and
 post that along with your original message. Then, anyone who wants to verify
 that Natoshi (i.e. the owner of the private key corresponding to the public key
 that belongs to Natoshi) did in fact publish a particular message can simply
 use Natoshi's public key to decrypt the encrypted signature and compare the
-content against the original message. Pretenders to Natoshi's throne will be
+content against the original message.
+
+Pretenders to Natoshi's throne will be
 unable to sign their false statements such that they can be verified with
 Natoshi's published public key because they don't have Natoshi's private key,
 and you can rest assured that no one will unduly influence your project in your
@@ -226,14 +235,19 @@ name while you go into hiding from the IRS and DEA, unless they happen to have
 warehouses full of ASICs and lots of cheap electricity.
 
 **However, in this scheme, how do you prevent an adversary from publishing a fake
-public key and claiming to be you** (they can make valid signatures against that
-fake public key)? Somehow, you need to "bootstrap" trust: someone would need to
+public key and claiming to be you?** (they can make valid signatures against that
+fake public key) Somehow, you need to "bootstrap" trust: someone would need to
 verify your identity and publicly affirm that your public key actually
-corresponds to you. We do this by means of **certificates**: a signed statement
+corresponds to you.
+
+We do this by means of **certificates**: a signed statement
 claiming that a particular public key does, in fact, belong to who it claims to
-belong to. Who signs this certificate? A **certificate authority**, someone we
-trust to be responsible about verifying identities and issuing signatures. But
-how do we know which CAs to trust, and how can we trust that a CA that claims
+belong to.
+
+Who signs this certificate? A **certificate authority**, someone we
+trust to be responsible about verifying identities and issuing signatures.
+
+But how do we know which CAs to trust, and how can we trust that a CA that claims
 to be trustworthy actually is? They probably need a certificate as well. It
 sounds like it might be turtles all the way down; however, the chain does end
 somewhere: the so-called root of trust, the root CAs. These are the CAs whose
@@ -290,10 +304,10 @@ Here's an example of hash functions at work. Enter the following commands on
 your student VM (i.e. `ssh username.decal.xcf.sh`) to calculate the SHA1[^sha1]
 hash of a 100MB file.
 
-1. `wget decal.ocf.berkeley.edu/static/a8/lab8.img`
-2. `sha1sum lab8.img`
+1. `wget decal.ocf.berkeley.edu/static/a9/lab9.jpg`
+2. `sha1sum lab9.jpg`
 
-You should see `fbd392c452040c72b08f73d90db972630056357`, a 40-digit string.
+You should see `685e925838358fdc162935588c6ee0aa5a5caed6`, a 40-digit string.
 As you can imagine, transferring this string is much easier than transferring a
 large, 100MB file, and because of the properties of the SHA-1 algorithm, you
 can be reasonably sure that this file, and only this file, will always hash to
@@ -301,8 +315,6 @@ that particular value. This means, if you want to verify that the file you
 downloaded hasn't been corrupted, you can simply compare the hashes (or more
 specifically, a signature over the hash) to ensure that the file you've
 downloaded hasn't been tampered with.
-
-
 
 
 # Encryption Lab Activity


### PR DESCRIPTION
All of the original files to complete a9 seem to be missing, so I have to go back and recreate them from the lab instructions. Additionally, I have some other changes made here to make things more readable. The other changes to check out are the files at `~decal/public_html/static/a9` or `https://decal.ocf.berkeley.edu/static/a9/`. If someone knows a way to put these static files in git, that would be a big help, or we could just move all of this to decal-labs so that we don't lose these files again. They even might still be around, I just havent been able to find them.