### PR TITLE
Fix task 2 filename in a9

### DIFF
--- a/labs/a9.md
+++ b/labs/a9.md
@@ -390,8 +390,8 @@ VM.[^ssh-copy-id]
 
 In order to explore encryption, we're going to be using the `gpg` command.
     
-1. Download[^wget] the file named `q1.gpg` from
-   [github](https://raw.githubusercontent.com/0xcf/decal-labs/master/a9),
+1. Download[^wget] the file named `q2.txt.gpg` from
+   [github](https://raw.githubusercontent.com/0xcf/decal-labs/master/a9/q2.txt.gpg),
    decrypt it using `gpg` and the password `weak_password`. **What is the 
    decrypted content?**
 


### PR DESCRIPTION
Should be `q2.txt.gpg` and not `q1.gpg`