### PR TITLE
Add message about certificate trust issues

### DIFF
--- a/labs/b1.md
+++ b/labs/b1.md
@@ -47,6 +47,8 @@ shape to explore them further next week!
 2. Run the following command to download the file we have provided:
    `wget https://decal.ocf.berkeley.edu/static/b1/b01.tgz`
 
+   * *If running `wget` results in a certificate not trusted error, run `wget https://decal.ocf.berkeley.edu/static/b1/b01.tgz --no-check-certificate instead.`*
+
    A `.tgz` file is actually a composition of two file formats. Sometimes
    you'll see these files as `.tar.gz` instead. A common (and old) way of
    archiving is with magnetic tapes. However, in order to archive the data, it


### PR DESCRIPTION
Running `wget` seems to create the error 
```
ERROR: The certificate of ‘decal.ocf.berkeley.edu’ is not trusted.
ERROR: The certificate of ‘decal.ocf.berkeley.edu’ hasn't got a known issuer.
```

This is a workaround for that (while we figure out what's going on).