### PR TITLE
Lab a6 updates

### DIFF
--- a/labs/a6.md
+++ b/labs/a6.md
@@ -321,7 +321,7 @@ In favor of not reinventing the wheel please check out these excellent and prett
 * **/etc/resolv.conf** file has 3 `nameserver` entries and a `options timeout:1` entry.
 * A successful DNS response takes 20 ms.
 
-    You need to add the `retry:n` option so that you retry a query as many times as possible but the total time to resolve a name, irrelevant of success or failure, takes less than **5** seconds.  What should the value of n be?
+    You need to add the `attempts:n` option so that you retry a query as many times as possible but the total time to resolve a name, irrelevant of success or failure, takes less than **5** seconds.  What should the value of n be?
 
 
 # Exercises

--- a/labs/a6.md
+++ b/labs/a6.md
@@ -337,9 +337,9 @@ The files for these exercises can be found in the [decal-labs][decal-labs] repos
 This section will have you thinking like a sysadmin.  
 
 ### IMPORTANT NOTE
-**Do not run the scripts directly in your student VM!** These scripts are **dangerous** and will brick your VM so **please follow the provided setup instructions.**
+**Do not run the scripts directly in your student VM!** These scripts are **dangerous** and will brick your VM so **please follow the provided setup instructions.** However, if you have physical access (or out-of-band management access) to a Linux machine, feel free to run the scripts directly and reboot when necessary, as all changes made are temporary.
 
-Each script might make changes to your network stack with the intent of damaging your machine's connectivity.  To confine the scope of the 'attacks', scripts will specifically try to alter your connectivity to `google.com` and `ocf.berkeley.edu`.
+Each script might make changes to your network stack with the intent of damaging your machine's connectivity. To confine the scope of the 'attacks', scripts will specifically try to alter your connectivity to `google.com` and `ocf.berkeley.edu`.
 
 ### Setup
 


### PR DESCRIPTION
For question 3b, there is no `retry:n` in Linux `/etc/resolv.conf`. For Solaris, however, there is indeed a `retry:n`: "Sets the number of attempts made to connect to _each_ name server". The Linux counterpart is `attempts:n`, which counts the total queries sent before giving up. See Oracle's manual and Linux Programmer's Manual for exact definitions.

Resolves #281 