### PR TITLE
Changed week 1 answer links

### DIFF
--- a/_data/materials.yaml
+++ b/_data/materials.yaml
@@ -9,8 +9,8 @@
   advanced-name: Advanced Introduction to UNIX
   advanced-slides: https://docs.google.com/presentation/d/1P4HcAr1NcxFEL1m9bIokiBP1zOODHj8YQMPFSafeWko/edit?usp=sharing
   advanced-video: https://www.youtube.com/watch?v=TBsxgbGwtnA
-  beginner-solutions: https://docs.google.com/document/d/13brUYoVtPL048ZnLDDGTkoHZwguHKVkKG3K9qsWVSHM/edit
-  advanced-solutions: https://docs.google.com/document/d/1_-zycSuSo6AQw4k7iHFSLpQNWx0Do6YS_Le7lIDHWFo/edit
+  beginner-solutions: https://docs.google.com/document/d/1SaaiUpLzfY6Mo8EJXhi9V_JK7V8Z2d5ctZsbeRWgzKU/edit?usp=sharing
+  advanced-solutions: https://docs.google.com/document/d/12IYqVnEZfSUz0wPUyItKP6M5Axbn4qjWeu0TJ72AHFU/edit?usp=sharing
   labdue: Sat. 9/11
   hidelink: false
 


### PR DESCRIPTION
I put the week 1 answers into a new folder for fall 2021, and shared it with the students based on the gradescope rosters.