### PR TITLE
add communication info to front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,16 +17,6 @@ seo:
 [Announcements](announcements.md){: .btn .btn-outline .fs-3 }
 {% endif %}
 
-## Communication
-Official course communications will primarily be sent via email and mirrored on the front page of the course website.
-
-There are several ways you can get in contact with course facilitators:
-1. Send a message on the course Piazza. (best for conceptual/debugging/content help)
-2. Send a message to #decal-general (or as a private message to a facilitator) either on [Slack](https://ocf.io/slack) or [Discord](https://ocf.io/discord). (best for realtime communications)
-3. Send an email to [decal@ocf.berkeley.edu](mailto:decal@ocf.berkeley.edu). (best for prospective students and matters that need to go on official record)
-
-See the [about page](/about) for more information.
-
 ## Weekly Schedule
 {% for schedule in site.schedules %}
 {{ schedule }}
@@ -85,7 +75,6 @@ Advanced Track
 : **Lab**{: .label .label-red}[Lab a{{week.id}}](/labs/a{{week.id}})
     : **Lab due {{week.labdue}}**
 {% endif %}
-
 </div>
 {% endfor %}
 

--- a/index.md
+++ b/index.md
@@ -17,6 +17,16 @@ seo:
 [Announcements](announcements.md){: .btn .btn-outline .fs-3 }
 {% endif %}
 
+## Communication
+Official course communications will primarily be sent via email and mirrored on the front page of the course website.
+
+There are several ways you can get in contact with course facilitators:
+1. Send a message on the course Piazza. (best for conceptual/debugging/content help)
+2. Send a message to #decal-general (or as a private message to a facilitator) either on [Slack](https://ocf.io/slack) or [Discord](https://ocf.io/discord). (best for realtime communications)
+3. Send an email to [decal@ocf.berkeley.edu](mailto:decal@ocf.berkeley.edu). (best for prospective students and matters that need to go on official record)
+
+See the [about page](/about) for more information.
+
 ## Weekly Schedule
 {% for schedule in site.schedules %}
 {{ schedule }}
@@ -75,20 +85,6 @@ Advanced Track
 : **Lab**{: .label .label-red}[Lab a{{week.id}}](/labs/a{{week.id}})
     : **Lab due {{week.labdue}}**
 {% endif %}
-
-## Communication
-Official course communications will primarily be sent via email, and mirrored on the front page of the course website.
-
-There are several ways you can get in contact with course facilitators:
-1. Send a message on the course Piazza. (best for conceptual/debugging/content help)
-2. Send a message to #decal-general (or as a private message to a facilitator) either on [Slack][slack] or [Discord][discord]. (best for realtime communications)
-3. Send an email to [decal@ocf.berkeley.edu][email]. (best for prospective students and matters that need to go on official record)
-
-See the [about page](about.md) for more information.
-
-[email]: mailto:decal@ocf.berkeley.edu
-[slack]: https://ocf.io/slack
-[discord]: https://ocf.io/discord
 
 </div>
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -75,6 +75,21 @@ Advanced Track
 : **Lab**{: .label .label-red}[Lab a{{week.id}}](/labs/a{{week.id}})
     : **Lab due {{week.labdue}}**
 {% endif %}
+
+## Communication
+Official course communications will primarily be sent via email, and mirrored on the front page of the course website.
+
+There are several ways you can get in contact with course facilitators:
+1. Send a message on the course Piazza. (best for conceptual/debugging/content help)
+2. Send a message to #decal-general (or as a private message to a facilitator) either on [Slack][slack] or [Discord][discord]. (best for realtime communications)
+3. Send an email to [decal@ocf.berkeley.edu][email]. (best for prospective students and matters that need to go on official record)
+
+See the [about page](about.md) for more information.
+
+[email]: mailto:decal@ocf.berkeley.edu
+[slack]: https://ocf.io/slack
+[discord]: https://ocf.io/discord
+
 </div>
 {% endfor %}
 

--- a/staff.md
+++ b/staff.md
@@ -7,6 +7,16 @@ description: A listing of all the course staff members.
 
 # Staff
 
+## Communication
+Official course communications will primarily be sent via email and mirrored on the front page of the course website.
+
+There are several ways you can get in contact with course facilitators:
+1. Send a message on the course Piazza. (best for conceptual/debugging/content help)
+2. Send a message to #decal-general (or as a private message to a facilitator) either on [Slack](https://ocf.io/slack) or [Discord](https://ocf.io/discord). (best for realtime communications)
+3. Send an email to [decal@ocf.berkeley.edu](mailto:decal@ocf.berkeley.edu). (best for prospective students and matters that need to go on official record)
+
+See the [about page](/about) for more information.
+
 ## Head Facilitators
 
 {% assign heads = site.staffers | where: 'role', 'Head Facilitator' %}


### PR DESCRIPTION
This is to minimize the number of students who email staff members directly. Adding this all to the front page might be extreme, but it allows users to read the page top-to-bottom to get all the information they need. This is especially helpful on mobile.