### PR TITLE
Update libvirt-bin for Ubuntu 20

### DIFF
--- a/labs/a3.md
+++ b/labs/a3.md
@@ -94,7 +94,7 @@ some packages that will allow us to create our nested Arch Linux VM.
 Run
 
 ```sh
-sudo apt install --no-install-recommends qemu-kvm qemu-utils libvirt-bin virtinst ovmf
+sudo apt install --no-install-recommends qemu-kvm qemu-utils libvirt-daemon-system libvirt-clients virtinst ovmf
 ```
 <div class="code-example" markdown="1">
 

--- a/labs/a3.md
+++ b/labs/a3.md
@@ -187,7 +187,7 @@ Now, we need to actually create our VM. **_(Don't run this command
 until you've read the next paragraph!)_** To do this, you will run
 
 ```sh
-sudo virt-install --name archvm --memory 704 --cpu host --vcpus 1 --disk size=5 --network network=default --boot uefi --graphics none --cdrom archlinux-2021.02.01-x86_64.iso
+sudo virt-install --name archvm --memory 704 --cpu host --vcpus 1 --disk size=5 --network network=default --boot uefi --graphics none --cdrom archlinux-2021.09.01-x86_64.iso
 ```
 
 This will do some initial setup, and then drop us into a virtual


### PR DESCRIPTION
Since we have Ubuntu 20 VM, libvirt-bin cannot be installed in this version. See [this](https://askubuntu.com/a/1089849) for more info