### PR TITLE
b4: remove ruby version number

### DIFF
--- a/labs/b4.md
+++ b/labs/b4.md
@@ -249,11 +249,12 @@ install `fpm` locally:
 
     $ gem install fpm --user
 
-Try invoking `fpm` and if it doesn’t work, add `~/.gem/ruby/2.5.0/bin` to your
+Try invoking `fpm`. If it doesn’t work, check your ruby version with `ruby --version` then add `~/.gem/ruby/<YOUR_VERSION>/bin` (where `<YOUR_VERSION>` is something like `2.7.0`) to your
 `PATH` (list of directories to find executables). To do that, add this to your `.bashrc`, or just type the following into
 Bash to temporarily add it to your PATH:
 
-    $ export PATH=~/.gem/ruby/2.5.0/bin:$PATH
+
+    $ export PATH=~/.gem/ruby/<YOUR_VERSION>/bin:$PATH
 
 Now we will create a very simple package using the `hellopenguin` executable
 that you made above. First, we will make a new folder named `packpenguin` and


### PR DESCRIPTION
From Piazza:

> The ruby version newly installed is 2.7.0, while the command in lab instruction says "to add ~/.gem/ruby/2.5.0/bin to your PATH (list of directories to find executables)" is outdated. So, the command should be ~/.gem/ruby/2.7.0/bin to allow fpm to be executable in bash. 

This PR removes the version number from the instructions, instead directing readers to check `ruby --version`.