### PR TITLE
Add lab contact info

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -202,6 +202,26 @@ layout: table_wrappers
       <div class="search-overlay"></div>
     {% endif %}
   </div>
+  {% if page.url == "/staff/" %}
+  <script>
+    function main() {
+      const url = window.location.href;
+      const idLocation = url.indexOf("#");
+
+      if(idLocation != -1 && url.length > idLocation + 1) {
+        const focusedElem = document.getElementById(url.substring(idLocation + 1));
+        const spotlight = document.createElement("div");
+        
+        spotlight.classList.add("spotlight");
+        focusedElem.parentElement.replaceChild(spotlight, focusedElem)
+        spotlight.appendChild(focusedElem);
+        spotlight.style = "width:auto; height:auto; background-color: rgba(200, 200, 0, 0.25); padding: 5px; border-radius: 10px";
+      }
+    }
+
+    window.onload = main;
+  </script>
+  {% endif %}
   <script>
     function setCookie(cname, cvalue, exdays) {
       const d = new Date();

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -216,6 +216,8 @@ layout: table_wrappers
         focusedElem.parentElement.replaceChild(spotlight, focusedElem)
         spotlight.appendChild(focusedElem);
         spotlight.style = "width:auto; height:auto; background-color: rgba(200, 200, 0, 0.25); padding: 5px; border-radius: 10px";
+        
+        spotlight.scrollIntoView();
       }
     }
 

--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -54,7 +54,7 @@ layout: table_wrappers
       <div id="main-content" class="main-content" role="main">
         <h1 style="margin-bottom:0">{{ page.title }}</h1>
         {% if page.facilitator != null %}
-        <p>By: <a href="/staff#{{ page.facilitator | replace: ' ', '-' | downcase }}">{{ page.facilitator }}</a></p>
+        <p>Facilitator: <a href="/staff#{{ page.facilitator | replace: ' ', '-' | downcase }}">{{ page.facilitator }}</a></p>
         {% endif %}
         {% assign minutes = content | strip_html | number_of_words | divided_by: 180.0 | round %}
         {{ minutes }} min read

--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -10,6 +10,7 @@ layout: table_wrappers
   {% include css/just-the-docs.scss.liquid %}
 </span>
 <body>
+  <div id="loading" style="height:140%;width:140%;background-color:#ffffff;position:absolute;z-index:1000;left:-20%;top:-20%"></div>
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <symbol id="svg-link" viewBox="0 0 24 24">
       <title>Link</title>
@@ -52,6 +53,7 @@ layout: table_wrappers
       {% endunless %}
       <div id="main-content" class="main-content" role="main">
         <h1>{{ page.title }}</h1>
+        <p>By: {{ page.facilitator }}</p>
         {% assign minutes = content | strip_html | number_of_words | divided_by: 180.0 | round %}
         {{ minutes }} min read
         {% if site.heading_anchors != false %}
@@ -64,44 +66,71 @@ layout: table_wrappers
       </div>
     </div>
   </div>
-  
-</body>
 
-<script>
-  function setCookie(cname, cvalue, exdays) {
-    const d = new Date();
-    d.setTime(d.getTime() + (exdays*24*60*60*1000));
-    let expires = "expires="+ d.toUTCString();
-    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-  }
-
-  function getCookie(cname) {
-    let name = cname + "=";
-    let decodedCookie = decodeURIComponent(document.cookie);
-    let ca = decodedCookie.split(';');
-    for(let i = 0; i <ca.length; i++) {
-      let c = ca[i];
-      while (c.charAt(0) == ' ') {
-        c = c.substring(1);
-      }
-      if (c.indexOf(name) == 0) {
-        return c.substring(name.length, c.length);
-      }
+  <script>
+    function setCookie(cname, cvalue, exdays) {
+      const d = new Date();
+      d.setTime(d.getTime() + (exdays*24*60*60*1000));
+      let expires = "expires="+ d.toUTCString();
+      document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
     }
-    return "";
-  }
-  let dark = !(window.matchMedia && 
-  window.matchMedia('(prefers-color-scheme: dark)').matches); // Flip dark so we can run one toggle on load
-  
-  let preference = getCookie("dark-mode");
 
-  if(preference == "1") {
-    dark = true;
-  } else if(preference == "0") {
-    dark = false;
-  }
+    function getCookie(cname) {
+      let name = cname + "=";
+      let decodedCookie = decodeURIComponent(document.cookie);
+      let ca = decodedCookie.split(';');
+      for(let i = 0; i <ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) == ' ') {
+          c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
+      }
+      return "";
+    }
 
-  let toggleDark = () => { jtd.setTheme(dark ? 'light' : 'dark'); setCookie("dark-mode", dark ? "1" : "0", 3652); dark = !dark; }
-  toggleDark();
-</script>
+    document.getElementById("loading").style["backgroundColor"] = getCookie("dark-mode") == 1 ? "#27262b" : "#ffffff" // Set the opaque layer to the prefered color
+
+    window.addEventListener('load', (event) => {
+      document.getElementById("loading").style = ""; // Remove the opaque layer when the page loads
+    });
+
+
+    let dark = !(window.matchMedia && 
+    window.matchMedia('(prefers-color-scheme: dark)').matches); // Flip dark so we can run one toggle on load
+    
+    let preference = getCookie("dark-mode");
+
+    if(preference == "1") {
+      dark = false;
+    } else if(preference == "0") {
+      dark = true;
+    }
+
+    let toggleDark = () => { 
+      jtd.setTheme(dark ? 'light' : 'dark'); 
+
+      // Change input text placeholder text color
+
+      const PLACEHOLDER_TEXT_COLOR = "#959396";
+
+      if(!dark) {
+        let placeholderStyleElem = document.head.appendChild(document.createElement("style"));
+        placeholderStyleElem.id = "placeholderTextStyle"
+        placeholderStyleElem.innerHTML = "::placeholder { color: " + PLACEHOLDER_TEXT_COLOR + "; opacity: 1 }\n"; // Firefox requires opacity
+        placeholderStyleElem.innerHTML += ":-ms-input-placeholder { color: " + PLACEHOLDER_TEXT_COLOR + "; }\n"; // IE 10+
+        placeholderStyleElem.innerHTML += "::-ms-input-placeholder { color: " + PLACEHOLDER_TEXT_COLOR + "; }\n"; // Edge
+      } else {
+        let placeholderStyleElem = document.getElementById("placeholderTextStyle");
+        if(placeholderStyleElem) placeholderStyleElem.remove();
+      }
+
+      setCookie("dark-mode", dark ? "0" : "1", 3652); 
+      dark = !dark;
+    }
+    toggleDark();
+  </script>
+</body>
 </html>

--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -52,8 +52,10 @@ layout: table_wrappers
         {% endif %}
       {% endunless %}
       <div id="main-content" class="main-content" role="main">
-        <h1>{{ page.title }}</h1>
-        <p>By: {{ page.facilitator }}</p>
+        <h1 style="margin-bottom:0">{{ page.title }}</h1>
+        {% if page.facilitator != null %}
+        <p>By: <a href="/staff#{{ page.facilitator | replace: ' ', '-' | downcase }}">{{ page.facilitator }}</a></p>
+        {% endif %}
         {% assign minutes = content | strip_html | number_of_words | divided_by: 180.0 | round %}
         {{ minutes }} min read
         {% if site.heading_anchors != false %}

--- a/_layouts/staffer.html
+++ b/_layouts/staffer.html
@@ -1,4 +1,4 @@
-<div class="staffer">
+<div class="staffer" id="{{ page.name | replace: ' ', '-' | downcase }}">
   {% if page.photo %}
   <img class="staffer-image" src="{{ site.baseurl }}{{ page.subpath }}{{ page.photo }}" alt="">
   {% endif %}

--- a/labs/11.md
+++ b/labs/11.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 11 - Bonus Lab!
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/a1.md
+++ b/labs/a1.md
@@ -1,6 +1,7 @@
 ---
 title: Lab a1 - Shell Scripting
 layout: lab
+facilitator: Ben Cuan
 nav_exclude: true
 ---
 

--- a/labs/a10.md
+++ b/labs/a10.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 10 - Containerization and Docker
 layout: lab
+facilitator: Ja Wattanawong
 nav_exclude: true
 ---
 

--- a/labs/a2.md
+++ b/labs/a2.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced Lab 2 - Packages and Packaging and Troubleshooting
 layout: lab
+facilitator: Samuel Berkun
 nav_exclude: true
 ---
 

--- a/labs/a3.md
+++ b/labs/a3.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced Lab 3 - Pre-install Setup and Installation
 layout: lab
+facilitator: Laksith
 nav_exclude: true
 ---
 

--- a/labs/a4.md
+++ b/labs/a4.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 4 - Linux Post-Install
 layout: lab
+facilitator: Ben Cuan
 nav_exclude: true
 ---
 

--- a/labs/a5.md
+++ b/labs/a5.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced Lab 5 - Processes and Services
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/a6.md
+++ b/labs/a6.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 6 - Networking 102
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/a7.md
+++ b/labs/a7.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 7 - Networked Services
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/a8.md
+++ b/labs/a8.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 8 - Configuration Management
 layout: lab
+facilitator: Ethan Smith
 nav_exclude: true
 ---
 

--- a/labs/a9.md
+++ b/labs/a9.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 9 - Security
 layout: lab
+facilitator: Mark Zhang
 nav_exclude: true
 ---
 

--- a/labs/b1.md
+++ b/labs/b1.md
@@ -1,6 +1,7 @@
 ---
 title: Beginner Lab 1 - Unix, the Shell, OSS
 layout: lab
+facilitator: Samuel Berkun
 nav_exclude: true
 ---
 

--- a/labs/b10.md
+++ b/labs/b10.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 10 - Containers and Configuration Management
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/b2.md
+++ b/labs/b2.md
@@ -1,6 +1,7 @@
 ---
 title: Beginner Lab 2 - Core Shell
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/b3.md
+++ b/labs/b3.md
@@ -1,6 +1,6 @@
 ---
 title: Lab 3 - Shell Scripting
-facilitator: Samuel Berkun
+facilitator: Laksith
 layout: lab
 nav_exclude: true
 ---

--- a/labs/b3.md
+++ b/labs/b3.md
@@ -1,5 +1,6 @@
 ---
 title: Lab 3 - Shell Scripting
+facilitator: Samuel Berkun
 layout: lab
 nav_exclude: true
 ---

--- a/labs/b4.md
+++ b/labs/b4.md
@@ -1,6 +1,7 @@
 ---
 title: Beginner Lab 4 - Debian, packages, compiling software
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/b5.md
+++ b/labs/b5.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 5 - Introduction to Networking
 layout: lab
+facilitator: Mark Zhang
 nav_exclude: true
 ---
 

--- a/labs/b6.md
+++ b/labs/b6.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 6 - Processes and Services
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/b7.md
+++ b/labs/b7.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 7 - Services
 layout: lab
+facilitator: Ben Plate
 nav_exclude: true
 ---
 

--- a/labs/b8.md
+++ b/labs/b8.md
@@ -1,6 +1,7 @@
 ---
 title: Lab 8 - Security Fundamentals
 layout: lab
+facilitator: null
 nav_exclude: true
 ---
 

--- a/labs/b9.md
+++ b/labs/b9.md
@@ -1,12 +1,9 @@
 ---
 title: Lab 9 - Version Control and Backups
-layout: page
+layout: lab
+facilitator: Bill Mao
 nav_exclude: true
 ---
-
-## Git IRL
-
-
 
 ## Table of contents
 {: .no_toc .text-delta }


### PR DESCRIPTION
Adds a facilitator title to each lab using facilitator list from the Google Doc. If there isn't a slot in the spreadsheet, the facilitator is ignored. There were also some facilitators I didn't know which profile to put for them, so I left blank.

Each lab markdown has a new `facilitator` property. It should be their name in their associated `_staffer` markdown file:
```md
---
title: Lab a1 - Shell Scripting
layout: lab
facilitator: Ben Cuan
nav_exclude: true
---

...
```

If no facilitator, it is null:
```md
---
title: Lab 6 - Processes and Services
layout: lab
facilitator: null
nav_exclude: true
---

...
```

Example:
<img width="803" alt="1" src="https://user-images.githubusercontent.com/16968917/135343118-028041f6-a960-4b4a-92d5-9d474fe9decf.png">

Clicking on the link will take the viewer to the staff page at the location of the staffer with a spotlight effect around them:
<img width="1267" alt="2" src="https://user-images.githubusercontent.com/16968917/135343189-7248d722-51f1-45e3-bab7-5bdd717992ff.png">

If no facilitator found, page will appear as normal:
<img width="777" alt="3" src="https://user-images.githubusercontent.com/16968917/135343219-335bfec5-52ff-4ebe-b067-d59ba983bec9.png">

I haven't been able to get Jekyll cooperatively working with my host and domain so it would be best to get hosted before. Also it may be good to address those labs with people assigned to facilitate, but no associated file (as far as I know) in `_staffers` (njha, ajanse, etc.). 