### PR TITLE
Update virtualenv to python 3 version in lab a5

### DIFF
--- a/labs/a5.md
+++ b/labs/a5.md
@@ -71,7 +71,7 @@ We will also need to install some dependencies. Go ahead and execute the followi
 
 ```
 # apt update
-# apt install build-essential make python-virtualenv
+# apt install build-essential make python3-virtualenv
 ```
 
 Now run `./run`. This should start up a simple web server at http://yourvm.decal.xcf.sh:5000. (Again... might need to open the port in your firewall.)


### PR DESCRIPTION
python-virtualenv uses python2, and is no longer supported in Ubuntu 20.04. python3-virtualenv works as a drop in replacement.