### PR TITLE
b7: Fix updated package 

### DIFF
--- a/labs/b7.md
+++ b/labs/b7.md
@@ -58,7 +58,7 @@ We will also need to install some dependencies. Go ahead and execute the followi
 
 ```
 sudo apt update
-sudo apt install build-essential make python-virtualenv
+sudo apt install build-essential make python3-virtualenv
 ```
 
 Now run `./run`. This should start up a simple web server at `http://yourvm.decal.xcf.sh:5000`


### PR DESCRIPTION
Change `python-virtualenv` to `python3-virtualenv`. The package was moved and trying to install `python-virtualenv` results in an error.