### PR TITLE
Fix docs relative links

### DIFF
--- a/labs/s2.md
+++ b/labs/s2.md
@@ -24,7 +24,7 @@ This time, we will take a whirlwind tour of some of the cool things we have arou
 
 The exercises below are best when done after completing the [Shell Spelunking portion of Decal Lab b1](https://decal.ocf.berkeley.edu/labs/b1/#shell-spelunking). If you are not enrolled in the Decal and would like access to the Gradescope to save your answers, please ask a [facilitator](https://decal.ocf.berkeley.edu/staff/) to add you (at least one should be in the lab if you're here in person), or send a message in #decal-comm.
 
-**You are encouraged (and, in some instances, practically required) to use all external resources at your disposal, including Google, [OCF documentation](new.ocf.io/docs), and other staff members, to complete any portion of this and future labs.** Doing so is not cheating, and you should keep using them for any contributions you make to the OCF.
+**You are encouraged (and, in some instances, practically required) to use all external resources at your disposal, including Google, [OCF documentation](https://new.ocf.io/docs), and other staff members, to complete any portion of this and future labs.** Doing so is not cheating, and you should keep using them for any contributions you make to the OCF.
 
 ## The OCF Servers
 
@@ -37,7 +37,7 @@ Here's a quick terminology guide:
 
 ## RTFM! (Scavenger Hunt)
 
-You will need [the OCF documentation](new.ocf.io/docs) to complete the following exercises. Try to get as far as you can, but don't be afraid to ask for help if you've been digging for a while and still can't find anything!
+You will need [the OCF documentation](https://new.ocf.io/docs) to complete the following exercises. Try to get as far as you can, but don't be afraid to ask for help if you've been digging for a while and still can't find anything!
 
 The following tasks will need to be completed on an OCF desktop, possibly SSH'ed into supernova (`ssh supernova` when logged into a desktop).
 


### PR DESCRIPTION
The links to OCF docs used a relative link so it wouldn't hyperlink properly :(