### PR TITLE
Fix Request Tracker (RT)

### DIFF
--- a/labs/s3.md
+++ b/labs/s3.md
@@ -58,7 +58,7 @@ Find some minutes that were taken in the year you were born (or, 1989 if you are
 
 ## RT
 
-As you might imagine, the OCF gets a lot of emails (users asking for help, clubs wanting to make a website, companies giving infosessions...) and it can get pretty hard to keep track of them all. As a solution, the OCF uses [Request Tracker (RT)][rt.ocf.io]. Here, incoming emails and requests are split up into queues. Here are a few:
+As you might imagine, the OCF gets a lot of emails (users asking for help, clubs wanting to make a website, companies giving infosessions...) and it can get pretty hard to keep track of them all. As a solution, the OCF uses [Request Tracker (RT)](rt.ocf.io). Here, incoming emails and requests are split up into queues. Here are a few:
 * **bod** contains topics that staff would like to bring up during BoD meetings. You are welcome to make a new ticket in this queue if there's something you want to discuss.
 * **devnull** mostly contains spam, advertisements, and other low-priority emails. You can safely ignore this queue.
 * **help** typically contains questions from users. Most of our time on RT is on responding to these tickets.

--- a/labs/s3.md
+++ b/labs/s3.md
@@ -58,7 +58,7 @@ Find some minutes that were taken in the year you were born (or, 1989 if you are
 
 ## RT
 
-As you might imagine, the OCF gets a lot of emails (users asking for help, clubs wanting to make a website, companies giving infosessions...) and it can get pretty hard to keep track of them all. As a solution, the OCF uses [Request Tracker (RT)](rt.ocf.io). Here, incoming emails and requests are split up into queues. Here are a few:
+As you might imagine, the OCF gets a lot of emails (users asking for help, clubs wanting to make a website, companies giving infosessions...) and it can get pretty hard to keep track of them all. As a solution, the OCF uses [Request Tracker (RT)](https://rt.ocf.io). Here, incoming emails and requests are split up into queues. Here are a few:
 * **bod** contains topics that staff would like to bring up during BoD meetings. You are welcome to make a new ticket in this queue if there's something you want to discuss.
 * **devnull** mostly contains spam, advertisements, and other low-priority emails. You can safely ignore this queue.
 * **help** typically contains questions from users. Most of our time on RT is on responding to these tickets.


### PR DESCRIPTION
There were brackets instead of parentheses around rt.ocf.io.